### PR TITLE
Send player's vote confirmation to group

### DIFF
--- a/MainController.py
+++ b/MainController.py
@@ -145,6 +145,8 @@ def handle_voting(bot, update):
             answer, game.board.state.nominated_president.name, game.board.state.nominated_chancellor.name), uid,
                               callback.message.message_id)
         log.info("Player %s (%d) voted %s" % (callback.from_user.first_name, uid, answer))
+        bot.send_message(game.cid, "%s registered a vote for President %s and Chancellor %s." % (
+            callback.from_user.first_name, game.board.state.nominated_president.name, game.board.state.nominated_chancellor.name))
         if uid not in game.board.state.last_votes:
             game.board.state.last_votes[uid] = answer
         if len(game.board.state.last_votes) == len(game.player_sequence):


### PR DESCRIPTION
Whenever voting starts, players don't know if a fellow player has voted. For each voting, players have to wait for every other player to vote.
This change tries to make it easier for players to know which player hasn't voted.
The bot will send a message to the group for each player that actually votes, and players, knowing which players havn't vote, can take the proper actions to continue the game.