### PR TITLE
Allow everybody to be selected as Chancellor after Anarchy

### DIFF
--- a/MainController.py
+++ b/MainController.py
@@ -411,6 +411,8 @@ def do_anarchy(bot, game):
     log.info('do_anarchy called')
     bot.send_message(game.cid, game.board.print_board())
     bot.send_message(game.cid, "ANARCHY!!")
+    game.board.state.president = None
+    game.board.state.chancellor = None
     top_policy = game.board.policies.pop(0)
     game.board.state.last_votes = {}
     enact_policy(bot, game, top_policy, True)


### PR DESCRIPTION
If you check the rulebook, you'll see that after the Anarchy, everybody is elegible as Chancellor.
Actually, this is not allowed by the bot. As it is controlled by the game.board.state. predient and chancellor, turning them into "None" will reflect properly the actual state of the game (during Anrchy, there are no president or chancellor). Then, everybody will be elegible for chancellor (except for the president) just as the start of the game.