### PR TITLE
Shuffling remaining policies

### DIFF
--- a/MainController.py
+++ b/MainController.py
@@ -331,6 +331,8 @@ def enact_policy(bot, game, policy, anarchy):
         game.board.state.game_endcode = -1
         end_game(bot, game, game.board.state.game_endcode)  # fascists win with 6 fascist policies
     sleep(3)
+    # End of legislative session, shuffle if necessary 
+    shuffle_policy_pile(bot, game)    
     if not anarchy:
         if policy == "fascist":
             action = game.board.fascist_track_actions[game.board.state.fascist_track - 1]


### PR DESCRIPTION
As per rules: after Anarchy or after a Legislative Session, if there are fewer than 3 policies in the policy deck, it has to be re-shuffled (right after anarchy or legislative session).
Usually, if no anarchy is applied, in the first round the deck goes from 5 policies to 2 policies. At this moment, the cards should be reshuffled (but they aren't). Instead, the bot wait for the next legislative session, shuffling them before handing out the cards to the president.
Same rule is broken if Anarchy applies a policy and results in fewer than 3 policies in the deck.